### PR TITLE
Configuration Extensions and Example Improvements

### DIFF
--- a/example/ecore-config.ts
+++ b/example/ecore-config.ts
@@ -1,3 +1,14 @@
+import { EditorConfiguration } from '../src/editor-config';
+import { ecoreSchema } from './schema';
+import {
+  attributeView,
+  datatypeView,
+  eClassView,
+  enumView,
+  ePackageView,
+  eReferenceView
+} from './uischema';
+
 export const labelProvider = {
   '#annotation': 'source',
   '#datatype': 'name',
@@ -38,3 +49,18 @@ export const modelMapping = {
     'http://www.eclipse.org/emf/2002/Ecore#//EAttribute': '#attribute'
   }
 };
+
+export const editorConfig: EditorConfiguration = {
+  dataSchema: ecoreSchema,
+  imageMapping: imageProvider,
+  labelMapping: labelProvider,
+  modelMapping: modelMapping,
+  detailSchemata: {
+    '#attribute': attributeView,
+    '#class': eClassView,
+    '#datatype': datatypeView,
+    '#enum': enumView,
+    '#package': ePackageView,
+    '#reference': eReferenceView,
+  }
+}

--- a/example/ecore-config.ts
+++ b/example/ecore-config.ts
@@ -1,10 +1,12 @@
 import { EditorConfiguration } from '../src/editor-config';
 import { ecoreSchema } from './schema';
 import {
+  annotationView,
   attributeView,
   datatypeView,
   eClassView,
   enumView,
+  eOperationView,
   ePackageView,
   eReferenceView
 } from './uischema';
@@ -21,14 +23,13 @@ export const labelProvider = {
   '#class': 'name',
   '#attribute': 'name',
   '#operation': 'name',
-  '#task': 'name',
-  '#user': 'name'
+  '#eliteral': 'name'
 };
 
 export const imageProvider = {
   '#datatype': 'datatype',
   '#enum': 'enum',
-  '#enumliteral': 'enumliteral',
+  '#eliteral': 'enumliteral',
   '#package': 'package',
   '#parameter': 'parameter',
   '#reference': 'reference',
@@ -56,11 +57,13 @@ export const editorConfig: EditorConfiguration = {
   labelMapping: labelProvider,
   modelMapping: modelMapping,
   detailSchemata: {
+    '#annotation': annotationView,
     '#attribute': attributeView,
     '#class': eClassView,
     '#datatype': datatypeView,
     '#enum': enumView,
+    '#operation': eOperationView,
     '#package': ePackageView,
     '#reference': eReferenceView,
   }
-}
+};

--- a/example/ecore-editor.ts
+++ b/example/ecore-editor.ts
@@ -30,13 +30,14 @@ export class EcoreEditor extends HTMLElement implements Editor {
 
       return;
     }
-    console.warn('Could not set data of ecore editor because it has not been rendered, yet.')
+    console.warn('Could not set data of ecore editor because it has not been rendered, yet.');
   }
 
   get data(): Object {
     if (this.editor !== undefined && this.editor !== null) {
       return this.editor.data;
     }
+
     return null;
   }
 

--- a/example/ecore-editor.ts
+++ b/example/ecore-editor.ts
@@ -1,20 +1,11 @@
-/* tslint:disable:no-invalid-this */
 import { JsonForms, JsonSchema } from 'jsonforms';
 import '../src/jsoneditor';
 import './ereference.renderer';
 import './eattribute.renderer';
 import { JsonEditor } from '../src/jsoneditor';
 import { Editor } from '../src/editor';
-import { imageProvider, labelProvider, modelMapping } from './ecore-config';
+import { editorConfig } from './ecore-config';
 import { ecoreSchema } from './schema';
-import {
-  attributeView,
-  datatypeView,
-  eClassView,
-  enumView,
-  ePackageView,
-  eReferenceView
-} from './uischema';
 
 export class EcoreEditor extends HTMLElement implements Editor {
   private dataObject: Object;
@@ -34,12 +25,19 @@ export class EcoreEditor extends HTMLElement implements Editor {
   }
 
   set data(data: Object) {
-    this.dataObject = data;
-    this.render();
+    if (this.editor !== undefined && this.editor !== null) {
+      this.editor.data = data;
+
+      return;
+    }
+    console.warn('Could not set data of ecore editor because it has not been rendered, yet.')
   }
 
   get data(): Object {
-    return this.dataObject;
+    if (this.editor !== undefined && this.editor !== null) {
+      return this.editor.data;
+    }
+    return null;
   }
 
   get schema(): JsonSchema {
@@ -49,47 +47,17 @@ export class EcoreEditor extends HTMLElement implements Editor {
 
     return undefined;
   }
-  private registerUiSchemas(): void {
-    this.editor.registerDetailSchema('#attribute', attributeView);
-    this.editor.registerDetailSchema('#class', eClassView);
-    this.editor.registerDetailSchema('#datatype', datatypeView);
-    this.editor.registerDetailSchema('#enum', enumView);
-    this.editor.registerDetailSchema('#package', ePackageView);
-    this.editor.registerDetailSchema('#reference', eReferenceView);
-  }
-
-  private configureLabelMapping() {
-    this.editor.setLabelMapping(labelProvider);
-  }
-
-  private configureImageMapping() {
-    this.editor.setImageMapping(imageProvider);
-  }
-
-  private configureModelMapping() {
-    // const callback = parsedResponse => {
-    this.editor.setModelMapping(modelMapping);
-    // };
-    // this.loadFromRest('http', callback);
-  }
 
   private render() {
-    if (!this.connected || this.dataObject === undefined
-        || this.dataObject === null) {
+    if (!this.connected) {
       return;
     }
     if (this.editor === undefined) {
       this.editor = document.createElement('json-editor') as JsonEditor;
+      this.editor.configure(editorConfig);
+      JsonForms.config.setIdentifyingProp('_id');
     }
 
-    this.configureImageMapping();
-    this.configureLabelMapping();
-    this.configureModelMapping();
-    this.registerUiSchemas();
-    this.editor.schema = ecoreSchema;
-
-    JsonForms.config.setIdentifyingProp('_id');
-    this.editor.data = this.dataObject;
     this.appendChild(this.editor);
   }
 }

--- a/example/index.ts
+++ b/example/index.ts
@@ -29,7 +29,6 @@ window.onload = () => {
   const downloadButton = document.getElementById('download-data-button') as HTMLButtonElement;
   configureDownloadButton(editor, downloadButton);
 
-  editor.data = {};
   document.getElementById('editor').appendChild(editor);
 
   applyMaterialStyle();

--- a/example/schema.ts
+++ b/example/schema.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:max-file-line-count */
 export const ecoreSchema = {
   'definitions': {
     'eLiterals': {
@@ -11,9 +12,11 @@ export const ecoreSchema = {
           'type': 'string'
         },
         'value': {
-          'type': 'integer'
+          'type': 'integer',
+          'default': 0
         }
-      }
+      },
+      'required': ['name']
     },
     'eClassifier': {
       'anyOf': [
@@ -43,7 +46,8 @@ export const ecoreSchema = {
       'type': 'object',
       'properties': {
         'eClass': {
-          'type': 'string'
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EAnnotation'
         },
         '_id': {
           'type': 'string'
@@ -93,6 +97,7 @@ export const ecoreSchema = {
           }
         }
       },
+      'required': ['name'],
       'additionalProperties': false
     },
     'datatype': {
@@ -125,6 +130,7 @@ export const ecoreSchema = {
           }
         }
       },
+      'required': ['name'],
       'additionalProperties': false
     },
     'eclass': {
@@ -156,6 +162,10 @@ export const ecoreSchema = {
         'interface': {
           'type': 'boolean'
         },
+        'eSuperTypes': {
+          'type': 'array',
+          'items': { 'type': 'string' }
+        },
         'eStructuralFeatures': {
           'type': 'array',
           'items': {
@@ -168,139 +178,7 @@ export const ecoreSchema = {
         'eOperations': {
           'type': 'array',
           'items': {
-            'id': '#operation',
-            'type': 'object',
-            'properties': {
-              'eClass': {
-                'type': 'string'
-              },
-              '_id': {
-                'type': 'string'
-              },
-              'name': {
-                'type': 'string'
-              },
-              'ordered': {
-                'type': 'boolean'
-              },
-              'unique': {
-                'type': 'boolean'
-              },
-              'lowerBound': {
-                'type': 'integer'
-              },
-              'upperBound': {
-                'type': 'integer'
-              },
-              'many': {
-                'type': 'boolean'
-              },
-              'required': {
-                'type': 'boolean'
-              },
-              'eType': {
-                'type': 'string'
-              },
-              'eTypeParameters': {
-                'type': 'array',
-                'items': {
-                  'id': '#typeparameter',
-                  'type': 'object',
-                  'properties': {
-                    'eClass': {
-                      'type': 'string'
-                    },
-                    '_id': {
-                      'type': 'string'
-                    },
-                    'name': {
-                      'type': 'string'
-                    }
-                  },
-                  'additionalProperties': false
-                }
-              },
-              'eParameters': {
-                'type': 'array',
-                'items': {
-                  'id': '#parameter',
-                  'type': 'object',
-                  'properties': {
-                    'eClass': {
-                      'type': 'string'
-                    },
-                    '_id': {
-                      'type': 'string'
-                    },
-                    'name': {
-                      'type': 'string'
-                    },
-                    'ordered': {
-                      'type': 'boolean'
-                    },
-                    'unique': {
-                      'type': 'boolean'
-                    },
-                    'lowerBound': {
-                      'type': 'integer'
-                    },
-                    'upperBound': {
-                      'type': 'integer'
-                    },
-                    'many': {
-                      'type': 'boolean'
-                    },
-                    'required': {
-                      'type': 'boolean'
-                    },
-                    'eType': {
-                      'type': 'string'
-                    },
-                    'eGenericType': {
-                      'type': 'object',
-                      'properties': {
-                        'eClass': {
-                          'type': 'string'
-                        },
-                        '_id': {
-                          'type': 'string'
-                        },
-                        'eClassifier': {
-                          'type': 'object',
-                          'properties': {
-                            'eClass': {
-                              'type': 'string'
-                            },
-                            '$ref': {
-                              'type': 'string'
-                            }
-                          },
-                          'additionalProperties': false
-                        },
-                        'eTypeArguments': {
-                          'type': 'array',
-                          'items': {
-                            'type': 'object',
-                            'properties': {
-                              'eClass': {
-                                'type': 'string'
-                              },
-                              '_id': {
-                                'type': 'string'
-                              }
-                            },
-                            'additionalProperties': false
-                          }
-                        }
-                      },
-                      'additionalProperties': false
-                    }
-                  },
-                  'additionalProperties': false
-                }
-              }
-            },
-            'additionalProperties': false
+            '$ref': '#/definitions/operation'
           }
         },
         'eAnnotations': {
@@ -310,6 +188,7 @@ export const ecoreSchema = {
           }
         }
       },
+      'required': ['name'],
       'additionalProperties': false
     },
     'attribute': {
@@ -379,6 +258,7 @@ export const ecoreSchema = {
           '$ref': '#/definitions/datatype'
         }
       }],
+      'required': ['name', 'eType'],
       'additionalProperties': false
     },
     'reference': {
@@ -457,6 +337,151 @@ export const ecoreSchema = {
           '$ref': '#/definitions/eclass'
         }
       }],
+      'required': ['name', 'eType'],
+      'additionalProperties': false
+    },
+    'operation': {
+      'id': '#operation',
+      'type': 'object',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EOperation'
+        },
+        '_id': {
+          'type': 'string'
+        },
+        'name': {
+          'type': 'string'
+        },
+        'ordered': {
+          'type': 'boolean'
+        },
+        'unique': {
+          'type': 'boolean'
+        },
+        'lowerBound': {
+          'type': 'integer'
+        },
+        'upperBound': {
+          'type': 'integer'
+        },
+        'many': {
+          'type': 'boolean'
+        },
+        'required': {
+          'type': 'boolean'
+        },
+        'eType': {
+          'type': 'string'
+        },
+        'eTypeParameters': {
+          'type': 'array',
+          'items': {
+            'id': '#typeparameter',
+            'type': 'object',
+            'properties': {
+              'eClass': {
+                'type': 'string'
+              },
+              '_id': {
+                'type': 'string'
+              },
+              'name': {
+                'type': 'string'
+              }
+            },
+            'additionalProperties': false
+          }
+        },
+        'eParameters': {
+          'type': 'array',
+          'items': {
+            'id': '#parameter',
+            'type': 'object',
+            'properties': {
+              'eClass': {
+                'type': 'string'
+              },
+              '_id': {
+                'type': 'string'
+              },
+              'name': {
+                'type': 'string'
+              },
+              'ordered': {
+                'type': 'boolean'
+              },
+              'unique': {
+                'type': 'boolean'
+              },
+              'lowerBound': {
+                'type': 'integer'
+              },
+              'upperBound': {
+                'type': 'integer'
+              },
+              'many': {
+                'type': 'boolean'
+              },
+              'required': {
+                'type': 'boolean'
+              },
+              'eType': {
+                'type': 'string'
+              },
+              'eGenericType': {
+                'type': 'object',
+                'properties': {
+                  'eClass': {
+                    'type': 'string'
+                  },
+                  '_id': {
+                    'type': 'string'
+                  },
+                  'eClassifier': {
+                    'type': 'object',
+                    'properties': {
+                      'eClass': {
+                        'type': 'string'
+                      },
+                      '$ref': {
+                        'type': 'string'
+                      }
+                    },
+                    'additionalProperties': false
+                  },
+                  'eTypeArguments': {
+                    'type': 'array',
+                    'items': {
+                      'type': 'object',
+                      'properties': {
+                        'eClass': {
+                          'type': 'string'
+                        },
+                        '_id': {
+                          'type': 'string'
+                        }
+                      },
+                      'additionalProperties': false
+                    }
+                  }
+                },
+                'additionalProperties': false
+              }
+            },
+            'additionalProperties': false
+          }
+        }
+      },
+      'links': [{
+        'rel': 'full',
+        'href': '#/eClassifiers/{eType}',
+        'targetSchema': {
+          '$ref': '#/definitions/eclass'
+        }
+      }],
+      'required': ['name'],
       'additionalProperties': false
     }
   },
@@ -490,5 +515,6 @@ export const ecoreSchema = {
       }
     }
   },
+  'required': ['name', 'nsURI', 'nsPrefix'],
   'additionalProperties': false
 };

--- a/example/uischema.ts
+++ b/example/uischema.ts
@@ -131,12 +131,6 @@ export const enumView = {
       'scope': {
         '$ref': '#/properties/name'
       }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/eLiterals'
-      }
     }
   ]
 };
@@ -343,6 +337,92 @@ export const eClassView = {
           }
         }
       ]
+    }
+  ]
+};
+
+export const eOperationView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Group',
+      'label': 'Standard',
+      'elements': [
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/name'
+          }
+        },
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/eType'
+          },
+          'options': {
+            'id': 'eReference'
+          }
+        },
+        {
+          'type': 'HorizontalLayout',
+          'elements': [
+            {
+              'type': 'Control',
+              'scope': {
+                '$ref': '#/properties/lowerBound'
+              }
+            },
+            {
+              'type': 'Control',
+              'scope': {
+                '$ref': '#/properties/upperBound'
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'type': 'Group',
+      'label': 'Advanced',
+      'elements': [
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/ordered'
+          }
+        },
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/required'
+          }
+        },
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/unique'
+          }
+        },
+        {
+          'type': 'Control',
+          'scope': {
+            '$ref': '#/properties/many'
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const annotationView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'scope': {
+        '$ref': '#/properties/source'
+      }
     }
   ]
 };

--- a/src/editor-config.ts
+++ b/src/editor-config.ts
@@ -1,14 +1,14 @@
-import { ModelMapping } from './modelmapping';
+import { JsonSchema, UISchemaElement } from 'jsonforms'
 
 /**
  * Contains all information needed to instantiate a customized JsonEditor.
- * TODO more precise types
  */
 export interface EditorConfiguration {
   /**
    * The schema defining the data editable in the editor.
+   * allOf, not, and oneOf constructs are not supported.
    */
-  dataSchema: Object;
+  dataSchema: JsonSchema; // TODO correct type?
 
   /**
    * The data to initialize the editor with.
@@ -25,22 +25,24 @@ export interface EditorConfiguration {
    * The UI Schema specifies rendered controls, layouts, and additional rendering information.
    * Thereby, the UI Schema is the same as the UI Schemata used in JsonForms 2.
    */
-  detailSchemata: Object; // TODO more precise type
+  detailSchemata?: {[schemaId: string]: UISchemaElement};
 
   /**
    * Configures the image mappings for the types defined in the editor's schema.
    * An image mapping maps from a schema id to the schema's image name.
    * This name is used to resolve the css style that configure a label
    * for instances of the type in the containment tree.
+   * Both the id and the name are configured as Strings.
    */
-  imageMapping?: Object;
+  imageMapping?: StringMap;
 
   /**
    * Configures the label mappings for the types defined in the editor's schema.
    * A label mapping maps from a schema id to a property defined in this schema.
    * This property defines the name of a rendered object in the containment tree.
+   * Both the id and the property name are configured as Strings.
    */
-  labelMapping?: Object;
+  labelMapping?: StringMap;
 
   /**
    * The model mapping defines mappings from a property value to a type.
@@ -56,7 +58,9 @@ export interface EditorConfiguration {
   modelMapping?: ModelMapping;
 
   /**
-   * Property names define the name of the data.
+   * Property names define the id of the data.
+   * This id is used in reference configuration to define
+   * which data is searched for reference targets.
    * The content is the actual data.
    * e.g.
    * {
@@ -64,5 +68,14 @@ export interface EditorConfiguration {
    *   'data2': { "name": "Bello", "species": "dog", "sex": "male"}
    * }
    */
-  referenceData?: Object;
+  referenceData?: { [property: string]: Object };
+}
+
+export interface StringMap {
+  [property: string]: string
+}
+
+export interface ModelMapping {
+  attribute: string;
+  mapping: StringMap;
 }

--- a/src/editor-config.ts
+++ b/src/editor-config.ts
@@ -1,4 +1,4 @@
-import { JsonSchema, UISchemaElement } from 'jsonforms'
+import { JsonSchema, UISchemaElement } from 'jsonforms';
 
 /**
  * Contains all information needed to instantiate a customized JsonEditor.
@@ -8,7 +8,7 @@ export interface EditorConfiguration {
    * The schema defining the data editable in the editor.
    * allOf, not, and oneOf constructs are not supported.
    */
-  dataSchema: JsonSchema; // TODO correct type?
+  dataSchema: JsonSchema;
 
   /**
    * The data to initialize the editor with.
@@ -58,8 +58,8 @@ export interface EditorConfiguration {
   modelMapping?: ModelMapping;
 
   /**
-   * Property names define the id of the data.
-   * This id is used in reference configuration to define
+   * Property names define the name of the resource.
+   * This name is used in reference configurations to define
    * which data is searched for reference targets.
    * The content is the actual data.
    * e.g.
@@ -68,11 +68,11 @@ export interface EditorConfiguration {
    *   'data2': { "name": "Bello", "species": "dog", "sex": "male"}
    * }
    */
-  referenceData?: { [property: string]: Object };
+  resources?: { [property: string]: Object };
 }
 
 export interface StringMap {
-  [property: string]: string
+  [property: string]: string;
 }
 
 export interface ModelMapping {

--- a/src/editor-config.ts
+++ b/src/editor-config.ts
@@ -1,0 +1,68 @@
+import { ModelMapping } from './modelmapping';
+
+/**
+ * Contains all information needed to instantiate a customized JsonEditor.
+ * TODO more precise types
+ */
+export interface EditorConfiguration {
+  /**
+   * The schema defining the data editable in the editor.
+   */
+  dataSchema: Object;
+
+  /**
+   * The data to initialize the editor with.
+   * If this is not set, the editor is initialized with the empty object {}.
+   */
+  data?: Object;
+
+  /**
+   * Object containing all UI Schemata for the JsonEditor.
+   * The name of the property containing the UI schema is its schema id.
+   * The property value is the UISchemaElement itself.
+   *
+   * A UI Schema is used when rendering a suitable object that was selected in the containment tree.
+   * The UI Schema specifies rendered controls, layouts, and additional rendering information.
+   * Thereby, the UI Schema is the same as the UI Schemata used in JsonForms 2.
+   */
+  detailSchemata: Object; // TODO more precise type
+
+  /**
+   * Configures the image mappings for the types defined in the editor's schema.
+   * An image mapping maps from a schema id to the schema's image name.
+   * This name is used to resolve the css style that configure a label
+   * for instances of the type in the containment tree.
+   */
+  imageMapping?: Object;
+
+  /**
+   * Configures the label mappings for the types defined in the editor's schema.
+   * A label mapping maps from a schema id to a property defined in this schema.
+   * This property defines the name of a rendered object in the containment tree.
+   */
+  labelMapping?: Object;
+
+  /**
+   * The model mapping defines mappings from a property value to a type.
+   * Thereby, the model mapping defines which property is considered.
+   * This property is the same for all types.
+   * A mapping maps from a specific value of this property to a schema id.
+   * If an element contains a mapped value in the defined property,
+   * it is assumed to be of the type defined by the mapped schema id.
+   *
+   * A model mapping is necessary for all types used in anyOf sections of a schema
+   * in order to determine which type objects of a "anyOf-property" belong to.
+   */
+  modelMapping?: ModelMapping;
+
+  /**
+   * Property names define the name of the data.
+   * The content is the actual data.
+   * e.g.
+   * {
+   *   'data1': { "name": "Robert", "age": 25 },
+   *   'data2': { "name": "Bello", "species": "dog", "sex": "male"}
+   * }
+   */
+  referenceData?: Object;
+}

--- a/src/jsoneditor.ts
+++ b/src/jsoneditor.ts
@@ -5,14 +5,14 @@ import {
   MasterDetailLayout,
   UISchemaElement
 } from 'jsonforms';
-import { ModelMapping } from './modelmapping';
+import { ModelMapping } from './editor-config';
 import { Editor } from './editor';
 import * as _ from 'lodash';
 import { EditorConfiguration } from './editor-config';
 
 export * from './toolbar';
 export * from './editor';
-export * from './modelmapping';
+export * from './editor-config';
 
 /**
  * The JsonEditor renders JSON data specified by a JSON Schema.

--- a/src/jsoneditor.ts
+++ b/src/jsoneditor.ts
@@ -8,6 +8,7 @@ import {
 import { ModelMapping } from './modelmapping';
 import { Editor } from './editor';
 import * as _ from 'lodash';
+import { EditorConfiguration } from './editor-config';
 
 export * from './toolbar';
 export * from './editor';
@@ -69,6 +70,42 @@ export class JsonEditor extends HTMLElement implements Editor {
    */
   get schema() {
     return this.dataSchema;
+  }
+
+  /**
+   * Configure the editor with an EditorConfiguration.
+   */
+  setConfiguration(config: EditorConfiguration) {
+    if (!_.isEmpty(config.imageMapping)) {
+      this.setImageMapping(config.imageMapping);
+    }
+    if (!_.isEmpty(config.labelMapping)) {
+      this.setLabelMapping(config.labelMapping);
+    }
+    if (!_.isEmpty(config.modelMapping)) {
+      this.setModelMapping(config.modelMapping);
+    }
+    // register all UI Schemata
+    if (!_.isEmtpy(config.detailSchemata)) {
+      Object.keys(config.detailSchemata).forEach(key => {
+        try {
+          const uiSchema = config.detailSchemata[key] as UISchemaElement;
+          this.registerDetailSchema(key, uiSchema);
+        } catch (e) {
+          console.warn(`Data registered for id '${key}' is not a valid UI Schema:`,
+                       config.detailSchemata[key]);
+        }
+      });
+    }
+    if (!_.isEmpty(config.referenceData)) {
+      // TODO handle/register/parse reference data
+    }
+    this.dataSchema = config.dataSchema;
+    if (!_.isEmpty(config.data)) {
+      this.data = config.data;
+    } else {
+      this.data = {};
+    }
   }
 
   /**

--- a/src/jsoneditor.ts
+++ b/src/jsoneditor.ts
@@ -73,9 +73,9 @@ export class JsonEditor extends HTMLElement implements Editor {
   }
 
   /**
-   * Configure the editor with an EditorConfiguration.
+   * Allows to configure the editor with a single EditorConfiguration object.
    */
-  setConfiguration(config: EditorConfiguration) {
+  configure(config: EditorConfiguration) {
     if (!_.isEmpty(config.imageMapping)) {
       this.setImageMapping(config.imageMapping);
     }
@@ -86,7 +86,7 @@ export class JsonEditor extends HTMLElement implements Editor {
       this.setModelMapping(config.modelMapping);
     }
     // register all UI Schemata
-    if (!_.isEmtpy(config.detailSchemata)) {
+    if (!_.isEmpty(config.detailSchemata)) {
       Object.keys(config.detailSchemata).forEach(key => {
         try {
           const uiSchema = config.detailSchemata[key] as UISchemaElement;

--- a/src/jsoneditor.ts
+++ b/src/jsoneditor.ts
@@ -97,8 +97,10 @@ export class JsonEditor extends HTMLElement implements Editor {
         }
       });
     }
-    if (!_.isEmpty(config.referenceData)) {
-      // TODO handle/register/parse reference data
+    if (!_.isEmpty(config.resources)) {
+      Object.keys(config.resources).forEach(name => {
+        this.registerResource(name, config.resources[name]);
+      });
     }
     this.dataSchema = config.dataSchema;
     if (!_.isEmpty(config.data)) {
@@ -141,6 +143,15 @@ export class JsonEditor extends HTMLElement implements Editor {
   setModelMapping(modelMapping: ModelMapping): void {
     JsonForms.modelMapping = modelMapping;
     this.masterDetail.options.modelMapping = modelMapping;
+  }
+
+  /**
+   * Register a resource for the given name.
+   * The resource can be used as reference target or to specify a reference target schema.
+   */
+  registerResource(name: string, resource: Object) {
+    // Register resource and resolve JSON References/Pointers
+    JsonForms.resources.registerResource(name, resource, true);
   }
 
   /**

--- a/src/jsoneditor.ts
+++ b/src/jsoneditor.ts
@@ -148,10 +148,14 @@ export class JsonEditor extends HTMLElement implements Editor {
   /**
    * Register a resource for the given name.
    * The resource can be used as reference target or to specify a reference target schema.
+   *
+   * @param name The name of the resource to register
+   * @param resource The resource data
+   * @param resolve Whether JSON References and Pointers in the resource should be resolved
    */
-  registerResource(name: string, resource: Object) {
+  registerResource(name: string, resource: Object, resolve = true) {
     // Register resource and resolve JSON References/Pointers
-    JsonForms.resources.registerResource(name, resource, true);
+    JsonForms.resources.registerResource(name, resource, resolve);
   }
 
   /**

--- a/src/modelmapping.ts
+++ b/src/modelmapping.ts
@@ -1,4 +1,0 @@
-export interface ModelMapping {
-  attribute: string;
-  mapping: object;
-}


### PR DESCRIPTION
- Defined a configuration object that allows to configure an editor with a single object
- The editor reads in this object and configures itself
- Allow to register resources to the editor
- adapted ecore example to use the configuration object
- Added validation to Ecore Schema
- Improved mappings and UI Schemata for the Ecore example